### PR TITLE
fix: fps limiter that actually limit fps

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -140,11 +140,15 @@ const setState = async (state: GameState) => {
 const gameLoop = (t: number): void => {
     requestAnimationFrame(gameLoop);
 
-    const dt = Math.min(t - lastTime, MAX_FRAME);
-    lastTime = t;
+    const deltaTime = t - lastTime;
 
-    update(t, dt);
-    draw(t, dt);
+    if (deltaTime >= TIME_STEP) {
+        const cappedDeltaTime = Math.min(deltaTime, MAX_FRAME);
+        lastTime = t - (deltaTime % TIME_STEP);
+
+        update(t, cappedDeltaTime);
+        draw(t, cappedDeltaTime);
+    }
 };
 
 const update = (t: number, dt: number): void => {


### PR DESCRIPTION
This should fix fps not limiting to 60.
Can be tested adjusting `const TIME_STEP = 1000 / 60;` like to 60 -> 10 and compare with the previous.