### PR TITLE
fix: music sync on start

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -282,7 +282,7 @@ const draw = (t: number, dt: number): void => {
                 }
 
                 if (radius > 0) {
-                    radius -= dt / 2;
+                    radius -= dt / 2.55; // Counting should match the music
                 }
             }
             applyGradient();


### PR DESCRIPTION
After changes on max fps, music versus counting went wrong. This fixes it.